### PR TITLE
return headers from `fetch_value`

### DIFF
--- a/.changeset/nice-pugs-remember.md
+++ b/.changeset/nice-pugs-remember.md
@@ -1,0 +1,5 @@
+---
+"@grogarden/util": minor
+---
+
+return headers from `fetch_value`

--- a/.changeset/nice-pugs-remember.md
+++ b/.changeset/nice-pugs-remember.md
@@ -1,5 +1,5 @@
 ---
-"@grogarden/util": minor
+'@grogarden/util': patch
 ---
 
 return headers from `fetch_value`

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -74,7 +74,7 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 		if (return_early_from_cache && cached) {
 			log?.info('[fetch_value] cached locally and returning early', url_str);
 			log?.debug('[fetch_value] cached value', cached);
-			return {ok: true, value: cached.value, headers: new Headers(cached.headers)};
+			return {ok: true, value: cached.value, headers: new Headers(TODO_reconstruct)};
 		}
 	}
 
@@ -128,7 +128,8 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 	if (res.status === 304) {
 		if (!cached) throw Error('unexpected 304 status without a cached value');
 		log?.info('[fetch_value] cache hit', url);
-		return {ok: true, value: cached.value, headers: new Headers(cached.headers)};
+		// TODO BLOCK construct headers using these values if cached
+		return {ok: true, value: cached.value, headers: new Headers(TODO_reconstruct)};
 	}
 
 	if (!res.ok) {
@@ -148,7 +149,6 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 			url: url_str,
 			params,
 			value: parsed,
-			// TODO BLOCK if this includes headers, we don't need to cache these separately
 			etag: res.headers.get('etag'),
 			last_modified: res.headers.get('etag') ? null : res.headers.get('last-modified'), // fall back to last-modified, ignoring if there's an etag
 		};

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -45,7 +45,8 @@ export interface Fetch_Value_Options<T_Value, T_Params = undefined> {
  * It's also stateless to avoid the complexity and bugs,
  * so we don't try to track `x-ratelimit-remaining` per domain.
  *
- * If the `value` is cached, only a safe subset of the `headers` are returned.
+ * If the `value` is cached, only the cached safe subset of the `headers` are returned.
+ * (currently just `etag` and `last-modified`)
  * Otherwise the full `res.headers` are included.
  */
 export const fetch_value = async <T_Value = any, T_Params = undefined>(

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -148,6 +148,7 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 			url: url_str,
 			params,
 			value: parsed,
+			// TODO BLOCK if this includes headers, we don't need to cache these separately
 			etag: res.headers.get('etag'),
 			last_modified: res.headers.get('etag') ? null : res.headers.get('last-modified'), // fall back to last-modified, ignoring if there's an etag
 		};

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -44,6 +44,9 @@ export interface Fetch_Value_Options<T_Value, T_Params = undefined> {
  *
  * It's also stateless to avoid the complexity and bugs,
  * so we don't try to track `x-ratelimit-remaining` per domain.
+ *
+ * If the `value` is cached, only a safe subset of the `headers` are returned.
+ * Otherwise the full `res.headers` are included.
  */
 export const fetch_value = async <T_Value = any, T_Params = undefined>(
 	url: string | URL,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -48,7 +48,7 @@ export interface Fetch_Value_Options<T_Value, T_Params = undefined> {
 export const fetch_value = async <T_Value = any, T_Params = undefined>(
 	url: string | URL,
 	options?: Fetch_Value_Options<T_Value, T_Params>,
-): Promise<Result<{value: T_Value}, {status: number; message: string}>> => {
+): Promise<Result<{value: T_Value; headers: Headers}, {status: number; message: string}>> => {
 	const {
 		request,
 		params,
@@ -74,7 +74,7 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 		if (return_early_from_cache && cached) {
 			log?.info('[fetch_value] cached locally and returning early', url_str);
 			log?.debug('[fetch_value] cached value', cached);
-			return {ok: true, value: cached.value};
+			return {ok: true, value: cached.value, headers: new Headers(cached.headers)};
 		}
 	}
 
@@ -128,7 +128,7 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 	if (res.status === 304) {
 		if (!cached) throw Error('unexpected 304 status without a cached value');
 		log?.info('[fetch_value] cache hit', url);
-		return {ok: true, value: cached.value};
+		return {ok: true, value: cached.value, headers: new Headers(cached.headers)};
 	}
 
 	if (!res.ok) {
@@ -154,7 +154,7 @@ export const fetch_value = async <T_Value = any, T_Params = undefined>(
 		cache!.set(key, result);
 	}
 
-	return {ok: true, value: parsed};
+	return {ok: true, value: parsed, headers: res.headers};
 };
 
 const print_headers = (headers: Headers): Record<string, string> => {
@@ -206,4 +206,4 @@ export const serialize_cache = (cache: Fetch_Value_Cache): string =>
 	JSON.stringify(Array.from(cache.entries()));
 
 export const deserialize_cache = (serialized: string): Fetch_Value_Cache =>
-	Fetch_Value_Cache.parse(new Map(JSON.parse(serialized)));
+	Fetch_Value_Cache.parse(new Map(JSON.parse(serialized))); // TODO BLOCK include headers?


### PR DESCRIPTION
Includes headers with `fetch_value`. Importantly, only a subset of the values get cached because it'd be a security and privacy footgun -- currently this just includes `etag` and `last-modified`.